### PR TITLE
Add compose configuration for marimo editing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["marimo", "edit", "notebook.py", "--host", "0.0.0.0", "--port", "8888"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: venv run compose
+
+venv:
+	python -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install -r requirements.txt
+
+run: venv
+        .venv/bin/marimo edit notebook.py --port 8888
+
+compose:
+       docker compose -f local.yml up --build

--- a/README.md
+++ b/README.md
@@ -48,3 +48,22 @@
 
 
 
+
+## 🚀 Quickstart
+
+To edit the example marimo notebook using Docker Compose and the `local.yml` file:
+
+```bash
+make compose
+```
+
+Then open <http://localhost:8888> in your browser.
+
+Or to use a local virtual environment:
+
+```bash
+make run
+```
+
+This will start the marimo server and open the `notebook.py` app.
+

--- a/local.yml
+++ b/local.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  marimo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8888:8888"
+    command: marimo edit notebook.py --host 0.0.0.0 --port 8888
+    volumes:
+      - .:/app

--- a/notebook.py
+++ b/notebook.py
@@ -1,0 +1,24 @@
+import marimo
+
+app = marimo.App()
+
+@app.cell
+def _():
+    import pandas as pd
+    import numpy as np
+    return pd, np
+
+@app.cell
+def _(pd, np):
+    dates = pd.date_range('2023-01-01', periods=100)
+    data = np.random.randn(100, 3).cumsum(axis=0)
+    df = pd.DataFrame(data, index=dates, columns=['AAPL', 'MSFT', 'GOOGL'])
+    df
+    return df
+
+@app.cell
+def _(df):
+    df.plot(title='Sample Prices')
+
+if __name__ == '__main__':
+    app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 marimo
 pandas
 
+numpy


### PR DESCRIPTION
## Summary
- update Dockerfile to start Marimo in edit mode
- expose the editor via compose with port 8888
- adjust Makefile and docs for editing workflow

## Testing
- `python -m py_compile notebook.py`
- ❌ `docker compose -f local.yml config` *(failed: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a88af96c8327ad0b15a84be9fbb7