### PR TITLE
Add marimo config loading module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+config.py
+
+__pycache__/

--- a/config.template.py
+++ b/config.template.py
@@ -1,0 +1,15 @@
+"""Configuration template for OpenQuantKit.
+
+Copy this file to ``config.py`` and edit the lists of tickers.
+Each key in ``TICKER_GROUPS`` represents a group name and maps to
+an iterable of ticker symbols.
+"""
+
+TICKER_GROUPS = {
+    # Example groups. Replace tickers with your own selections.
+    "REIT_DATA_CENTERS": ["DLR", "EQIX"],
+    "REIT_ENERGY": ["NEE", "DUK"],
+    "ENERGY_COMPANIES": ["XOM", "CVX"],
+    "CHIP_MANUFACTURERS": ["TSM", "INTC", "NVDA"],
+}
+


### PR DESCRIPTION
## Summary
- ignore configuration files and pycache
- add `config.template.py` as example ticker list
- implement marimo notebook to load config

## Testing
- `python -m py_compile notebook.py config.template.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b164a698832798210c14bcc8e5c1