### PR TITLE
Add init script and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,7 @@ venv: ## init virtual environment locally
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install -r requirements.txt
 
-run: ## executes the notebook on docker
+run: ## launch notebook using local venv
+	./init.sh
+compose: ## executes the notebook on docker
 	docker compose -f local.yml up --build

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+    python -m venv venv
+    ./venv/bin/pip install --upgrade pip
+    ./venv/bin/pip install -r requirements.txt
+fi
+
+# Activate the virtual environment
+source venv/bin/activate
+
+# Start the marimo notebook
+marimo edit notebook.py --host 0.0.0.0 --port 8888


### PR DESCRIPTION
## Summary
- add `init.sh` for setting up the local virtual environment and running the marimo notebook
- update Makefile to call `init.sh` via `make run`
- add `compose` target to run via Docker

## Testing
- `bash -n init.sh`
- `make help`

------
https://chatgpt.com/codex/tasks/task_e_6843edf1b08883278e5555409946f8d9