### PR TITLE
Switch price storage to parquet files

### DIFF
--- a/oqk/price_db.py
+++ b/oqk/price_db.py
@@ -1,28 +1,40 @@
 # oqk/price_db.py
 import os
 from datetime import date
-import duckdb
+import pandas as pd
 
 TABLE_NAME = "prices"
 
 
 def get_price_db_path(ticker: str, data_dir: str = "data") -> str:
-    return os.path.join(data_dir, f"{ticker}.duckdb")
+    return os.path.join(data_dir, f"{ticker}.parquet")
 
 
-def get_ticker_max_date(ticker: str, data_dir: str = "data") -> tuple[duckdb.DuckDBPyConnection, date | None]:
-    """
-    Opens or creates the per-ticker price DB and ensures the table exists.
-    Returns the DB connection and max recorded price date (or None).
-    """
-    db_path = get_price_db_path(ticker, data_dir)
-    conn = duckdb.connect(db_path)
+def get_ticker_max_date(ticker: str, data_dir: str = "data") -> date | None:
+    """Return the max date from the parquet price file if it exists."""
+    file_path = get_price_db_path(ticker, data_dir)
+    if not os.path.exists(file_path):
+        return None
 
     try:
-        result = conn.execute(f"SELECT MAX(date) FROM {TABLE_NAME}").fetchone()
-        max_date = result[0] if result and result[0] else None
+        df = pd.read_parquet(file_path, columns=["date"])
+        if df.empty:
+            return None
+        return pd.to_datetime(df["date"]).dt.date.max()
     except Exception:
-        conn.execute(f"CREATE TABLE IF NOT EXISTS {TABLE_NAME} (date DATE, close DOUBLE)")
-        max_date = None
+        return None
 
-    return conn, max_date
+
+def append_price_data(ticker: str, df: pd.DataFrame, data_dir: str = "data") -> None:
+    """Append a price DataFrame to the ticker's parquet file, creating it if needed."""
+    file_path = get_price_db_path(ticker, data_dir)
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"]).dt.date
+
+    if os.path.exists(file_path):
+        existing = pd.read_parquet(file_path)
+        df = pd.concat([existing, df], ignore_index=True)
+
+    df = df.sort_values("date").drop_duplicates("date", keep="last")
+    df.to_parquet(file_path, index=False)


### PR DESCRIPTION
## Summary
- store ticker price history in parquet files instead of DuckDB
- update the data update process to append prices to parquet

## Testing
- `black --line-length 120 --check oqk/price_db.py oqk/update_data.py`
- `make test` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee3f4ad5c8327ab64ae63909e071d