### PR TITLE
Separate raw ticker status from metrics

### DIFF
--- a/oqk/raw_ticker_db.py
+++ b/oqk/raw_ticker_db.py
@@ -1,0 +1,74 @@
+import os
+from datetime import date
+from typing import List
+
+import duckdb
+import pandas as pd
+from pandas.tseries.offsets import BDay
+
+from .ticker_downloader import populate_tickers_from_exchange
+
+DB_PATH = "tickers.duckdb"
+RAW_TABLE = "raw_tickers"
+
+
+def get_safe_lag_date() -> date:
+    """Return the last business day."""
+    return (pd.Timestamp.today() - BDay(1)).date()
+
+
+def init_raw_ticker_table(db_path: str = DB_PATH) -> None:
+    """Ensure the raw_tickers table exists."""
+    con = duckdb.connect(db_path)
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {RAW_TABLE} (
+            symbol TEXT PRIMARY KEY,
+            is_bad BOOLEAN DEFAULT FALSE
+        )
+        """
+    )
+    con.close()
+
+
+def ensure_raw_tickers_initialized(db_path: str = DB_PATH) -> None:
+    """Create the table and populate tickers if missing."""
+    db_exists = os.path.exists(db_path)
+    init_raw_ticker_table(db_path)
+
+    if not db_exists:
+        print("🆕 Database file didn't exist. Initializing fresh ticker data...")
+        populate_tickers_from_exchange(db_path)
+
+
+def get_valid_tickers(db_path: str = DB_PATH) -> List[str]:
+    """Return all tickers not marked as bad."""
+    ensure_raw_tickers_initialized(db_path)
+    con = duckdb.connect(db_path)
+    rows = con.execute(f"SELECT symbol FROM {RAW_TABLE} WHERE is_bad = FALSE ORDER BY symbol").fetchall()
+    con.close()
+    return [r[0] for r in rows]
+
+
+def mark_ticker_as_bad(symbol: str, db_path: str = DB_PATH) -> None:
+    """Mark a ticker as bad in the raw_tickers table."""
+    print(f"Bad ticker: {symbol}")
+    con = duckdb.connect(db_path)
+    con.execute(f"UPDATE {RAW_TABLE} SET is_bad = TRUE WHERE symbol = ?", (symbol,))
+    con.close()
+
+
+def print_raw_ticker_table_stats(db_path: str = DB_PATH) -> None:
+    """Print statistics about the raw tickers table."""
+    con = duckdb.connect(db_path)
+    print("\n📊 Raw Ticker Table Summary:")
+    try:
+        total = con.execute(f"SELECT COUNT(*) FROM {RAW_TABLE}").fetchone()[0]
+        bad = con.execute(f"SELECT COUNT(*) FROM {RAW_TABLE} WHERE is_bad = TRUE").fetchone()[0]
+
+        print(f"  • Total tickers : {total}")
+        print(f"  • Bad tickers   : {bad}")
+    except Exception as e:
+        print(f"  Error gathering analytics: {e}")
+
+    con.close()

--- a/oqk/ticker_downloader.py
+++ b/oqk/ticker_downloader.py
@@ -10,29 +10,20 @@ def populate_tickers_from_exchange(db_path: str = DB_PATH) -> None:
     """Download NASDAQ and NYSE tickers and insert them into the DB."""
     con = duckdb.connect(db_path)
 
-    count = con.execute("SELECT COUNT(*) FROM tickers").fetchone()[0]
+    count = con.execute("SELECT COUNT(*) FROM raw_tickers").fetchone()[0]
     if count > 0:
         con.close()
         return  # Already populated
 
     print("Downloading NASDAQ/NYSE tickers...")
 
-    nasdaq = pd.read_csv(
-        "ftp://ftp.nasdaqtrader.com/SymbolDirectory/nasdaqlisted.txt",
-        sep="|"
-    )
-    nyse = pd.read_csv(
-        "ftp://ftp.nasdaqtrader.com/SymbolDirectory/otherlisted.txt",
-        sep="|"
-    )
+    nasdaq = pd.read_csv("ftp://ftp.nasdaqtrader.com/SymbolDirectory/nasdaqlisted.txt", sep="|")
+    nyse = pd.read_csv("ftp://ftp.nasdaqtrader.com/SymbolDirectory/otherlisted.txt", sep="|")
 
     symbols = set(nasdaq["Symbol"].dropna().tolist() + nyse["ACT Symbol"].dropna().tolist())
     symbols = sorted(t for t in symbols if "test" not in t.lower())
 
-    con.executemany(
-        "INSERT INTO tickers (symbol) VALUES (?)",
-        [(s,) for s in symbols]
-    )
+    con.executemany("INSERT INTO raw_tickers (symbol) VALUES (?)", [(s,) for s in symbols])
     con.close()
 
     print(f"Saved {len(symbols)} tickers to DuckDB")

--- a/oqk/ticker_metrics.py
+++ b/oqk/ticker_metrics.py
@@ -4,7 +4,8 @@ import pandas as pd
 from datetime import timedelta
 from pandas.tseries.offsets import BDay
 
-from .ticker_db import get_safe_lag_date
+from .raw_ticker_db import get_safe_lag_date
+
 
 def compute_ticker_metrics(df: pd.DataFrame) -> dict:
     df = df.copy()

--- a/oqk/ticker_metrics_db.py
+++ b/oqk/ticker_metrics_db.py
@@ -1,0 +1,75 @@
+from datetime import date
+from typing import List
+
+import duckdb
+
+from .raw_ticker_db import RAW_TABLE, ensure_raw_tickers_initialized, get_safe_lag_date
+
+DB_PATH = "tickers.duckdb"
+METRICS_TABLE = "ticker_stats"
+
+
+def init_metrics_table(db_path: str = DB_PATH) -> None:
+    """Create the table to store ticker statistics."""
+    con = duckdb.connect(db_path)
+    con.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {METRICS_TABLE} (
+            symbol TEXT PRIMARY KEY,
+            data_duration_days INTEGER,
+            num_data_points INTEGER,
+            completeness_ratio DOUBLE,
+            largest_gap_days INTEGER,
+            num_gaps_gt_3_days INTEGER,
+            num_gaps_gt_5_days INTEGER,
+            std_close DOUBLE,
+            num_zero_close INTEGER,
+            first_date DATE,
+            last_date DATE,
+            weekday_coverage DOUBLE,
+            has_recent_data BOOLEAN,
+            num_duplicate_dates INTEGER
+        )
+        """
+    )
+    con.close()
+
+
+def update_ticker_metrics(symbol: str, metrics: dict, db_path: str = DB_PATH) -> None:
+    """Upsert metrics for a ticker into the ticker_stats table."""
+    con = duckdb.connect(db_path)
+    columns = ["symbol"] + list(metrics.keys())
+    placeholders = ", ".join(["?"] * len(columns))
+    updates = ", ".join([f"{k}=excluded.{k}" for k in metrics.keys()])
+    sql = (
+        f"INSERT INTO {METRICS_TABLE} ({', '.join(columns)}) "
+        f"VALUES ({placeholders}) "
+        f"ON CONFLICT(symbol) DO UPDATE SET {updates}"
+    )
+    con.execute(sql, [symbol] + list(metrics.values()))
+    con.close()
+
+
+def update_last_date(symbol: str, last_date: date, db_path: str = DB_PATH) -> None:
+    """Convenience wrapper to record only the last_date for a ticker."""
+    update_ticker_metrics(symbol, {"last_date": last_date}, db_path)
+
+
+def get_tickers_needing_update(db_path: str = DB_PATH) -> List[str]:
+    """Return tickers without recent data and not marked bad."""
+    ensure_raw_tickers_initialized(db_path)
+    init_metrics_table(db_path)
+    con = duckdb.connect(db_path)
+    safe_lag_date = get_safe_lag_date()
+    rows = con.execute(
+        f"""
+        SELECT r.symbol
+        FROM {RAW_TABLE} r
+        LEFT JOIN {METRICS_TABLE} m ON r.symbol = m.symbol
+        WHERE r.is_bad = FALSE AND (m.last_date IS NULL OR m.last_date < ?)
+        ORDER BY m.last_date NULLS FIRST
+        """,
+        (safe_lag_date,),
+    ).fetchall()
+    con.close()
+    return [r[0] for r in rows]


### PR DESCRIPTION
## Summary
- keep only `symbol` and `is_bad` columns in `raw_tickers`
- expose helpers in `ticker_metrics_db` for last-date updates and retrieving tickers to update
- adapt downloader and update pipeline to new tables

## Testing
- `black --check oqk/raw_ticker_db.py oqk/ticker_metrics_db.py oqk/update_data.py oqk/ticker_downloader.py oqk/ticker_metrics.py --line-length 120`
- `make test` *(fails: `docker: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684ee55b87688327a06a0134d74829cf